### PR TITLE
[feat] 소셜로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -43,6 +44,9 @@ dependencies {
 
     // postgresql
     implementation 'org.postgresql:postgresql:42.6.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/AuthController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/AuthController.java
@@ -1,0 +1,44 @@
+package org.farmsystem.sotserver.domain.user.controller;
+
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.service.OauthService;
+import org.farmsystem.sotserver.domain.user.service.TokenService;
+import org.farmsystem.sotserver.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+
+    private final OauthService oauthService;
+    private final TokenService tokenService;
+
+    // 임시 토큰 발급 API
+    @PostMapping("/token/{userId}")
+    public ResponseEntity<SuccessResponse<?>> getTempToken(@PathVariable Long userId) {
+        UserTokenResponseDTO userToken = tokenService.issueTempToken(userId);
+        return SuccessResponse.ok(userToken);
+    }
+
+    // 소셜 로그인
+    @PostMapping("/login")
+    public ResponseEntity<SuccessResponse<?>> socialLogin(@RequestBody @Valid UserLoginRequestDTO userLoginRequest) {
+        UserTokenResponseDTO userToken = oauthService.socialLogin(userLoginRequest);
+        return SuccessResponse.ok(userToken);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal Long userId) {
+        tokenService.logout(userId);
+        return SuccessResponse.ok(null);
+    }
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
@@ -16,11 +16,4 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class UserController {
     private final UserService userService;
-
-    // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
-    @PostMapping("/token/{userId}")
-    public ResponseEntity<SuccessResponse<?>> getTempToken(@PathVariable Long userId) {
-        UserTokenResponseDTO userToken = userService.issueTempToken(userId);
-        return SuccessResponse.ok(userToken);
-    }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UserLoginRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UserLoginRequestDTO.java
@@ -1,0 +1,16 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.farmsystem.sotserver.domain.user.entity.SocialType;
+
+
+import java.util.Optional;
+
+public record UserLoginRequestDTO(
+        @NotBlank
+        String code,
+        @NotNull
+        SocialType socialType
+) {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UserTokenRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UserTokenRequestDTO.java
@@ -1,0 +1,9 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserTokenRequestDTO(
+        @NotBlank
+        String accessToken
+) {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/UserTokenResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/UserTokenResponseDTO.java
@@ -1,9 +1,8 @@
 package org.farmsystem.sotserver.domain.user.dto.response;
 
-public record UserTokenResponseDTO(
-        String accessToken
-) {
+public record UserTokenResponseDTO(String accessToken) {
     public static UserTokenResponseDTO of(String accessToken) {
         return new UserTokenResponseDTO(accessToken);
     }
 }
+

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/SocialType.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/SocialType.java
@@ -1,0 +1,5 @@
+package org.farmsystem.sotserver.domain.user.entity;
+
+public enum SocialType {
+    KAKAO
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -12,4 +12,18 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
+
+    private String socialId;
+
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus userStatus;
+
+    public User(String socialId, String imageUrl, UserStatus userStatus) {
+        this.socialId = socialId;
+        this.imageUrl = imageUrl;
+        this.userStatus = userStatus;
+    }
 }
+

--- a/src/main/java/org/farmsystem/sotserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package org.farmsystem.sotserver.domain.user.repository;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+import java.util.Optional;
 
+public interface UserRepository extends JpaRepository<User,Long> {
+    Optional<User> findBySocialId(String socialId);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthService.java
@@ -1,0 +1,50 @@
+package org.farmsystem.sotserver.domain.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.entity.SocialType;
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final OauthTokenProvider oauthTokenProvider;
+    private final OauthUserResourceProvider oauthUserResourceProvider;
+    private final TokenService tokenService;
+    private final UserService userService;
+
+    @Transactional
+    public UserTokenResponseDTO socialLogin(UserLoginRequestDTO userLoginRequest){
+        SocialType socialType = userLoginRequest.socialType();
+
+        // OAuth 토큰 가져오기
+        String oauthToken = oauthTokenProvider.getOauthToken(userLoginRequest.code(), socialType);
+
+        // 사용자 정보 가져오기
+        JsonNode userResource = oauthUserResourceProvider.getUserResource(oauthToken, socialType);
+
+        // 사용자 정보 처리
+        Map<String, String> userInfo = oauthUserResourceProvider.extractUserInfo(userResource, socialType);
+        String socialId = userInfo.get("socialId");
+        String imageUrl = userInfo.get("imageUrl");
+
+        // 사용자 저장
+        User user = userService.saveUser(socialId, imageUrl, userLoginRequest);
+
+        // JWT 토큰 발급
+        return tokenService.issueToken(user.getUserId());
+
+    }
+
+
+
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthTokenProvider.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthTokenProvider.java
@@ -1,0 +1,71 @@
+package org.farmsystem.sotserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.sotserver.domain.user.entity.SocialType;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.OAUTH_TOKEN_REQUEST_FAILED;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class OauthTokenProvider {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    public String getOauthToken(String code, SocialType socialType) {
+        try {
+            if (!socialType.equals(SocialType.KAKAO)) {
+                throw new BusinessException(OAUTH_TOKEN_REQUEST_FAILED); // 불필요한 소셜 타입 방어
+            }
+
+            String oauthTokenApiUrl = "https://kauth.kakao.com/oauth/token";
+            String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+            requestBody.add("code", decodedCode);
+            requestBody.add("client_id", kakaoClientId);
+            requestBody.add("client_secret", kakaoClientSecret);
+            requestBody.add("redirect_uri", kakaoRedirectUri);
+            requestBody.add("grant_type", "authorization_code");
+
+            HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    oauthTokenApiUrl,
+                    HttpMethod.POST,
+                    requestEntity,
+                    Map.class
+            );
+
+            return (String) response.getBody().get("access_token");
+        } catch (Exception e) {
+            log.error("OAuth 토큰 요청 중 오류 발생: ", e);
+            throw new BusinessException(OAUTH_TOKEN_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthUserResourceProvider.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthUserResourceProvider.java
@@ -1,0 +1,53 @@
+package org.farmsystem.sotserver.domain.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.sotserver.domain.user.entity.SocialType;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.OAUTH_USER_RESOURCE_FAILED;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class OauthUserResourceProvider {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public JsonNode getUserResource(String accessToken, SocialType socialType) {
+        try {
+            String userResourceApiUrl = "https://kapi.kakao.com/v2/user/me";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + accessToken);
+
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(userResourceApiUrl, HttpMethod.GET, entity, String.class);
+
+            return new ObjectMapper().readTree(response.getBody());
+        } catch (Exception e) {
+            log.error("OAuth 사용자 정보 요청 중 오류 발생: ", e);
+            throw new BusinessException(OAUTH_USER_RESOURCE_FAILED);
+        }
+    }
+
+    public Map<String, String> extractUserInfo(JsonNode userResource, SocialType socialType) {
+        String socialId = userResource.path("id").asText();
+        String imageUrl = userResource.path("kakao_account").path("profile").path("profile_image_url").asText();
+        return Map.of("socialId", socialId, "imageUrl", imageUrl);
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/TokenService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/TokenService.java
@@ -1,0 +1,57 @@
+package org.farmsystem.sotserver.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.user.dto.request.UserTokenRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
+import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
+import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
+import org.farmsystem.sotserver.global.error.exception.UnauthorizedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.JSON_PARSING_FAILED;
+import static org.farmsystem.sotserver.global.error.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    public String issueNewAccessToken(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        return jwtProvider.getIssueToken(userId, true);
+    }
+
+    public UserTokenResponseDTO issueTempToken(Long userId) {
+        String accessToken = issueNewAccessToken(userId);
+        return UserTokenResponseDTO.of(accessToken);
+    }
+
+    public UserTokenResponseDTO issueToken(Long userId) {
+        String accessToken = jwtProvider.getIssueToken(userId, true);
+        return UserTokenResponseDTO.of(accessToken);
+    }
+
+    public UserTokenResponseDTO reissue(UserTokenRequestDTO userTokenRequest) {
+        Long userId;
+        try {
+            userId = Long.valueOf(jwtProvider.decodeJwtPayloadSubject(userTokenRequest.accessToken()));
+        } catch (JsonProcessingException e) {
+            throw new UnauthorizedException(JSON_PARSING_FAILED);
+        }
+
+        String newAccessToken = issueNewAccessToken(userId);
+        return UserTokenResponseDTO.of(newAccessToken);
+    }
+
+    public void logout(Long userId) {
+        // 로그아웃 시 특별히 처리할 내용 없음 (리프레시 토큰 없음)
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -2,23 +2,32 @@ package org.farmsystem.sotserver.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
 import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.domain.user.entity.UserStatus;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class UserService {
+    private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public String issueNewAccessToken(Long userId) {
-        return jwtProvider.getIssueToken(userId, true);
+    public User saveUser(String socialId, String imageUrl, UserLoginRequestDTO request) {
+        return userRepository.findBySocialId(socialId)
+                .orElseGet(() -> userRepository.save(
+                        new User(socialId, imageUrl, UserStatus.ACTIVE)
+                ));
     }
+
     public UserTokenResponseDTO issueTempToken(Long userId) {
-        String accessToken = issueNewAccessToken(userId);
+        String accessToken = jwtProvider.getIssueToken(userId, true);
         return UserTokenResponseDTO.of(accessToken);
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/global/config/CorsConfig.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package org.farmsystem.sotserver.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -13,6 +14,13 @@ import java.util.List;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    @Value("${spring.deployment.frontend.local}")
+    private String frontendLocal;
+
+    @Value("${spring.deployment.backend.production}")
+    private String backendProduction;
+
+
     @Bean
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -21,9 +29,10 @@ public class CorsConfig implements WebMvcConfigurer {
 
         // CORS 허용할 URL
         List<String> allowedOrigins = Arrays.asList(
-                "http://localhost:5000" // 프론트 주소 추가 필요
+                "http://localhost:5173",
+                frontendLocal,
+                backendProduction
         );
-
         config.setAllowedOrigins(allowedOrigins);
 
         config.addAllowedHeader("*");

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
 
     // 토큰 없이 접근 가능한 URL
     private static final String[] whiteList = {"/",
-            "api/user/token/**",
+            "api/auth/token/**",
+            "api/auth/login/**"
             };
 
     @Bean

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -49,7 +49,23 @@ public enum ErrorCode {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    /**
+     * Oauth Error
+     */
+    OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 토큰 요청에 실패하였습니다."),
+    OAUTH_USER_RESOURCE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 사용자 정보 조회에 실패하였습니다."),
+    JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 파싱에 실패하였습니다."),
+
+    /**
+     * User Error
+     */
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "다른 소셜 계정으로 이미 가입된 사용자입니다."),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #6 
 
## 🌱 작업 사항
- 소셜로그인 (리프레시 토큰 X)
- 로컬에서 Redis 설정 안 되어있으면 하기! @sw4796 

## 🌱 참고 사항
- 로컬에서 소셜로그인하기 (가입이랑 합쳐져있으니 처음에 해줘야 함)
<img width="866" alt="스크린샷 2025-05-21 오후 9 08 00" src="https://github.com/user-attachments/assets/7ea7b0ba-fcf3-49f6-8e42-e1cff67a93dd" />
여기에서 code는 `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=YOUR_REST_API_KEY&redirect_uri=YOUR_REDIRECT_URI` 여기로 들어가서, 바뀐 주소를 보면 code가 써있어요. 이걸 사용하면 됩니다.
YOUR_REST_API_KEY와 YOUR_REDIRECT_URI는 공유된 application.yml 참고바랍니다!
redirect uri는 로컬에서 돌리면 localhost:8080으로 해주면 됩니다!

개발할 때만 사용할 임시토큰 발급하기 -> DB에서 userId확인하시고 http://localhost:8080/api/auth/token/{userId}로 요청 보내시면 됩니다!
<img width="887" alt="스크린샷 2025-05-21 오후 9 10 20" src="https://github.com/user-attachments/assets/687e0029-0539-4f2f-8f43-4bca937679ec" />
