### PR TITLE
[feat] 권한 제어하기

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/Role.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/Role.java
@@ -1,0 +1,7 @@
+package org.farmsystem.sotserver.domain.user.entity;
+
+public enum Role {
+    ROLE_USER, // 동국대 이메일 인증 된 회원
+    ROLE_PENDING,  // 동국대 이메일 인증 전
+    ROLE_ADMIN // 관리자 권한
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -18,12 +18,14 @@ public class User {
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
-    private UserStatus userStatus;
+    private Role role;
 
-    public User(String socialId, String imageUrl, UserStatus userStatus) {
+    public User(String socialId, String imageUrl, Role role) {
         this.socialId = socialId;
         this.imageUrl = imageUrl;
-        this.userStatus = userStatus;
+        this.role = role;
     }
+
+
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/UserStatus.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/UserStatus.java
@@ -1,8 +1,0 @@
-package org.farmsystem.sotserver.domain.user.entity;
-
-public enum UserStatus {
-    ACTIVE,
-    INACTIVE,
-    DELETED
-}
-

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
 import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.entity.Role;
 import org.farmsystem.sotserver.domain.user.entity.User;
-import org.farmsystem.sotserver.domain.user.entity.UserStatus;
 import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,8 @@ public class UserService {
     public User saveUser(String socialId, String imageUrl, UserLoginRequestDTO request) {
         return userRepository.findBySocialId(socialId)
                 .orElseGet(() -> userRepository.save(
-                        new User(socialId, imageUrl, UserStatus.ACTIVE)
+                        // 동국대학교 인증 전 기본 권한은 ROLE_PENDING
+                        new User(socialId, imageUrl, Role.ROLE_PENDING)
                 ));
     }
 

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/CustomUserDetails.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/CustomUserDetails.java
@@ -1,0 +1,45 @@
+package org.farmsystem.sotserver.global.config.auth;
+
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getUserId());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/CustomUserDetailsService.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package org.farmsystem.sotserver.global.config.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
+import org.farmsystem.sotserver.global.error.ErrorCode;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return new CustomUserDetails(user);
+    }
+}
+

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.farmsystem.sotserver.global.config.auth;
 
 import lombok.RequiredArgsConstructor;
 
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.config.CorsConfig;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtAuthenticationEntryPoint;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtAuthenticationFilter;
@@ -23,6 +24,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CorsConfig corsConfig;
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     // 토큰 없이 접근 가능한 URL
     private static final String[] whiteList = {"/",
@@ -48,7 +50,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
                 .addFilter(corsConfig.corsFilter())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtAuthenticationFilter.java
@@ -4,10 +4,12 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
+import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;
 import org.farmsystem.sotserver.global.config.auth.UserAuthentication;
 import org.farmsystem.sotserver.global.error.ErrorCode;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
 import org.farmsystem.sotserver.global.error.exception.UnauthorizedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -16,11 +18,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
+import static org.farmsystem.sotserver.global.error.ErrorCode.USER_NOT_FOUND;
+
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -40,8 +44,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(HttpServletRequest request, Long userId) {
-        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        UserAuthentication authentication = new UserAuthentication(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserRepository userRepository) {
+        this.jwtProvider = jwtProvider;
+        this.userRepository = userRepository;
+    }
+
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #6 
 
## 🌱 작업 사항
- 동국대 인증 / 동국대 인증 전 / (관리자) 권한 분리를 위한 작업

## 🌱 참고 사항
컨트롤러에서 사용방법 예시 @sw4796 @hysong4u 
```
@GetMapping("/me")
public ResponseEntity<ProfileDTO> getProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
    Long userId = userDetails.getUserId();
    ...
}

```

SpringSecurity URI 경로별 권한 제어 방법 예시 2가지
1. 메서드별 세세한 권한 제어
```
@PreAuthorize("hasRole('USER')")
@GetMapping("/protected")
public String onlyForUsers() {
    return "You are USER";
}

```
- 컨트롤러 메서드 실행 직전에 AOP 기반으로 동작
- 메서드 단위로 세밀하게 권한을 제어
@EnableMethodSecurity가 활성화되어 있어야 함.


2. Spring security에서 URI경로 묶어서 제어
```
.authorizeHttpRequests(auth -> auth
    .requestMatchers("/api/admin/**").hasRole("ADMIN")
    .requestMatchers("/api/owner/**").hasRole("OWNER")
    .requestMatchers("/api/user/**").hasAnyRole("USER", "ADMIN")
    .requestMatchers("/api/auth/**", "/").permitAll()
    .anyRequest().authenticated()
)

```
- URL 패턴 단위로 필터링을 통해 권한을 검사
- Spring Security의 FilterChain에서 수행되므로, 컨트롤러 진입 전에 걸러짐
- URL 구조에 따라 전체적인 접근 제어 정책을 관리