### PR TITLE
[feat]#13 게시물 댓글 API 구현

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/controller/ArticleController.java
@@ -2,9 +2,7 @@ package org.farmsystem.sotserver.domain.article.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.sotserver.domain.article.dto.ArticleCreateRequest;
-import org.farmsystem.sotserver.domain.article.dto.ArticleResponse;
-import org.farmsystem.sotserver.domain.article.dto.ArticleStatusRequest;
+import org.farmsystem.sotserver.domain.article.dto.*;
 import org.farmsystem.sotserver.domain.article.service.ArticleService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
 import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;
@@ -36,7 +34,7 @@ public class ArticleController {
             @RequestPart(value = "images", required = false) List<MultipartFile> images
             ) {
         Long userId = userDetails.getUserId();
-        ArticleResponse response = articleService.createArticle(userId, images, request);
+        ArticleCreateResponse response = articleService.createArticle(userId, images, request);
         return SuccessResponse.created(response);
     }
 
@@ -49,7 +47,7 @@ public class ArticleController {
             @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
         Long userId = userDetails.getUserId();
-        ArticleResponse response = articleService.updateArticle(articleId, userId, images, request);
+        ArticleCreateResponse response = articleService.updateArticle(articleId, userId, images, request);
         return SuccessResponse.ok(response);
     }
 
@@ -61,7 +59,7 @@ public class ArticleController {
             @RequestBody @Valid ArticleStatusRequest request
     ) {
         Long userId = userDetails.getUserId();
-        ArticleResponse response = articleService.changeStatus(articleId, userId, request);
+        ArticleCreateResponse response = articleService.changeStatus(articleId, userId, request);
         return SuccessResponse.ok(response);
     }
 
@@ -79,13 +77,13 @@ public class ArticleController {
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getArticles(
             @PageableDefault(size = 10, sort = "articleId", direction = Sort.Direction.DESC) Pageable pageable){
-        Page<ArticleResponse> articles = articleService.getArticles(pageable);
+        Page<ArticleListResponse> articles = articleService.getArticles(pageable);
         return SuccessResponse.ok(articles);
     }
 
     @GetMapping("/{articleId}")
     public ResponseEntity<SuccessResponse<?>> getArticle(@PathVariable Long articleId) {
-        ArticleResponse response = articleService.getArticle(articleId);
+        ArticleDetailResponse response = articleService.getArticle(articleId);
         return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleCreateResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleCreateResponse.java
@@ -11,18 +11,18 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class ArticleResponse {
+public class ArticleCreateResponse {
     private Long id;
     private String title;
     private String content;
     private Long userId;
     private ArticleStatus status;
-    LocalDateTime createAt;
-    LocalDateTime updateAt;
-    List<String> imageUrls;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+    private List<String> imageUrls;
 
-    public static ArticleResponse from(Article article, S3Uploader s3Uploader) {
-        return new ArticleResponse(
+    public static ArticleCreateResponse from(Article article, S3Uploader s3Uploader) {
+        return new ArticleCreateResponse(
                 article.getArticleId(),
                 article.getTitle(),
                 article.getContent(),

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleDetailResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleDetailResponse.java
@@ -1,0 +1,45 @@
+package org.farmsystem.sotserver.domain.article.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
+import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
+import org.farmsystem.sotserver.global.s3.S3Uploader;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ArticleDetailResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private ArticleStatus status;
+    private Long userId;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+    private List<String> imageUrls;
+
+    // 댓글 정보 필드 추가
+    private List<CommentResponse> comments;
+
+    public static ArticleDetailResponse from(Article article, S3Uploader s3Uploader, List<CommentResponse> comments) {
+        return ArticleDetailResponse.builder()
+                .id(article.getArticleId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .userId(article.getAuthor().getUserId())
+                .status(article.getStatus())
+                .createAt(article.getCreatedAt())
+                .updateAt(article.getUpdatedAt())
+                .imageUrls(article.getImages().stream()
+                        .map(img -> s3Uploader.getFileUrl(img.getKey()))
+                        .toList())
+                .comments(comments)
+                .build();
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleListResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/ArticleListResponse.java
@@ -1,0 +1,45 @@
+package org.farmsystem.sotserver.domain.article.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Builder;
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
+import org.farmsystem.sotserver.global.s3.S3Uploader;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ArticleListResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private ArticleStatus status;
+    private Long userId;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+    private List<String> imageUrls;
+
+    // 댓글 개수 필드
+    private int commentCount;
+
+    // 팩토리 메서드
+    public static ArticleListResponse from(Article article, S3Uploader s3Uploader, int commentCount) {
+        return ArticleListResponse.builder()
+                .id(article.getArticleId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .status(article.getStatus())
+                .userId(article.getAuthor().getUserId())
+                .createAt(article.getCreatedAt())
+                .updateAt(article.getUpdatedAt())
+                .imageUrls(article.getImages().stream()
+                        .map(img -> s3Uploader.getFileUrl(img.getKey()))
+                        .toList())
+                .commentCount(commentCount)
+                .build();
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
@@ -1,14 +1,15 @@
 package org.farmsystem.sotserver.domain.article.service;
 
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.sotserver.domain.article.dto.ArticleCreateRequest;
-import org.farmsystem.sotserver.domain.article.dto.ArticleResponse;
-import org.farmsystem.sotserver.domain.article.dto.ArticleStatusRequest;
+import org.farmsystem.sotserver.domain.article.dto.*;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
 import org.farmsystem.sotserver.domain.article.entity.Image;
 import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
 import org.farmsystem.sotserver.domain.article.repository.ImageRepository;
+import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
+import org.farmsystem.sotserver.domain.comment.entity.Comment;
+import org.farmsystem.sotserver.domain.comment.repository.CommentRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
@@ -30,8 +31,9 @@ public class ArticleService {
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
     private final S3Uploader s3Uploader;
+    private final CommentRepository commentRepository;
 
-    public ArticleResponse createArticle(Long userId, List<MultipartFile> images, ArticleCreateRequest request){
+    public ArticleCreateResponse createArticle(Long userId, List<MultipartFile> images, ArticleCreateRequest request){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
@@ -46,11 +48,11 @@ public class ArticleService {
 
         Article saved = articleRepository.save(article);
 
-        return ArticleResponse.from(saved, s3Uploader);
+        return ArticleCreateResponse.from(saved, s3Uploader);
     }
 
     @Transactional
-    public ArticleResponse updateArticle(Long articleId, Long userId, List<MultipartFile> images, ArticleCreateRequest request){
+    public ArticleCreateResponse updateArticle(Long articleId, Long userId, List<MultipartFile> images, ArticleCreateRequest request){
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다."));
 
@@ -71,11 +73,11 @@ public class ArticleService {
         article.getImages().clear();
         uploadImages(article, images);
 
-        return ArticleResponse.from(article, s3Uploader);
+        return ArticleCreateResponse.from(article, s3Uploader);
     }
 
     @Transactional
-    public ArticleResponse changeStatus(Long articleId, Long userId, ArticleStatusRequest request){
+    public ArticleCreateResponse changeStatus(Long articleId, Long userId, ArticleStatusRequest request){
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
@@ -85,7 +87,7 @@ public class ArticleService {
 
         article.changeStatus(request.getStatus());
 
-        return ArticleResponse.from(article, s3Uploader);
+        return ArticleCreateResponse.from(article, s3Uploader);
     }
 
     @Transactional
@@ -107,16 +109,26 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public ArticleResponse getArticle(Long articleId){
+    public ArticleDetailResponse getArticle(Long articleId){
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
-        return ArticleResponse.from(article, s3Uploader);
+
+        //댓글 가져오기
+        List<Comment> commentList = commentRepository.findByArticle_ArticleId(articleId);
+        List<CommentResponse> commentResponses = commentList.stream()
+                .map(CommentResponse::from)
+                .toList();
+
+        return ArticleDetailResponse.from(article, s3Uploader, commentResponses);
     }
 
     @Transactional(readOnly = true)
-    public Page<ArticleResponse> getArticles(Pageable pageable){
-        return articleRepository.findAll(pageable)
-                .map(article -> ArticleResponse.from(article, s3Uploader));
+    public Page<ArticleListResponse> getArticles(Pageable pageable){
+        Page<Article> page = articleRepository.findAll(pageable);
+        return page.map(article -> {
+            int commentCount = commentRepository.countByArticle_ArticleId(article.getArticleId());
+            return ArticleListResponse.from(article, s3Uploader, commentCount);
+        });
     }
 
     private void uploadImages(Article article, List<MultipartFile> images) {

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/controller/CommentController.java
@@ -1,0 +1,56 @@
+package org.farmsystem.sotserver.domain.comment.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.comment.dto.CommentCreateRequest;
+import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
+import org.farmsystem.sotserver.domain.comment.service.CommentService;
+import org.farmsystem.sotserver.global.common.SuccessResponse;
+import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/article/")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PostMapping("{articleId}/comments")
+    public ResponseEntity<SuccessResponse<?>> createComment(
+            @PathVariable("articleId") Long articleId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid CommentCreateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+        CommentResponse commentResponse = commentService.createComment(articleId, userId, request);
+        return SuccessResponse.created(commentResponse);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @PatchMapping("comments/{commentId}")
+    public ResponseEntity<SuccessResponse<?>> updateComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid CommentCreateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+        CommentResponse commentResponse =  commentService.updateComment(commentId, userId, request);
+        return SuccessResponse.ok(commentResponse);
+    }
+
+    @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+    @DeleteMapping("comments/{commentId}")
+    //@PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        commentService.deleteComment(commentId, userDetails.getUserId());
+        return SuccessResponse.noContent();
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,15 @@
+package org.farmsystem.sotserver.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequest {
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,33 @@
+package org.farmsystem.sotserver.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.farmsystem.sotserver.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class CommentResponse {
+    private Long commentId;
+    private String content;
+    private Long userId;
+    private Long articleId;
+    private String userName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CommentResponse from(Comment comment) {
+        return CommentResponse.builder()
+                .commentId(comment.getCommentId())
+                .content(comment.getContent())
+                .userId(comment.getUser().getUserId())
+                .articleId(comment.getArticle().getArticleId())
+                .userName(comment.getUser().getSocialId()) // 원하는 정보로 변경 가능
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/entity/Comment.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/entity/Comment.java
@@ -20,14 +20,19 @@ public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
+
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id")
     private Article article;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void updateComment(String content){
+        this.content = content;
+    }
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package org.farmsystem.sotserver.domain.comment.repository;
+
+import org.farmsystem.sotserver.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+    List<Comment> findByArticle_ArticleId(Long articleId);
+    int countByArticle_ArticleId(Long articleId);
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/comment/service/CommentService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/comment/service/CommentService.java
@@ -1,0 +1,74 @@
+package org.farmsystem.sotserver.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
+import org.farmsystem.sotserver.domain.comment.dto.CommentCreateRequest;
+import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
+import org.farmsystem.sotserver.domain.comment.entity.Comment;
+import org.farmsystem.sotserver.domain.comment.repository.CommentRepository;
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long articleId, Long userId, CommentCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다"));
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다"));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .user(user)
+                .article(article)
+                .build();
+        commentRepository.save(comment);
+
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, Long userId, CommentCreateRequest request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다."));
+
+        if(!comment.getUser().getUserId().equals(userId))
+        {
+            throw new SecurityException("본인만 댓글을 수정할 수 있습니다.");
+        }
+
+        comment.updateComment(request.getContent());
+
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByArticle(Long articleId) {
+        List<Comment> comments = commentRepository.findByArticle_ArticleId(articleId);
+        return comments.stream()
+                .map(CommentResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다"));
+        if (!comment.getUser().getUserId().equals(userId)) {
+            throw new SecurityException("본인만 댓글을 삭제할 수 있습니다");
+        }
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -26,6 +26,5 @@ public class User {
         this.role = role;
     }
 
-
 }
 


### PR DESCRIPTION
-댓글 생성, 수정, 삭제 구현
-게시물 단일 조회시 댓글 리스트 조회 구현
-게시물 목록 조회시 댓글 개수 제공 구현
-게시물 응답 DTO 추가

## 🌱 관련 이슈
- close : #13 
 
## 🌱 작업 사항
- 댓글 생성, 수정, 삭제 API 구현
- 게시물 조회시 댓글 정보 추가

## 🌱 참고 사항
- 댓글 수정 API 추가 (API 명세서에 추가)
- 댓글 조회는 게시물 단일 조회시 조회되도록 구현
댓글 개별 조회 API는 따로 안만들었음
