### PR TITLE
[feat] 마이페이지 수정 & 질문폼 생성 조회 API 구현 

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -2,14 +2,14 @@ package org.farmsystem.sotserver.domain.form.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
 import org.farmsystem.sotserver.domain.form.service.FormService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -18,12 +18,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class FormController {
 
     private final FormService formService;
+
+    // 폼 생성 (질문 생성)
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createForm(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @RequestBody FormCreateRequestDTO formCreateRequest){
         formService.createForm(userId, formCreateRequest);
         return SuccessResponse.created(null);
+    }
+
+    // 폼 질문 조회
+    @GetMapping("/{formId}/question")
+    public ResponseEntity<SuccessResponse<?>> getFormQuestions(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long formId ) {
+        List<FormQuestionResponseDTO> formQuestions = formService.getFormQuestions(userId, formId);
+        return SuccessResponse.ok(formQuestions);
     }
 
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -1,0 +1,29 @@
+package org.farmsystem.sotserver.domain.form.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.service.FormService;
+import org.farmsystem.sotserver.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/api/form")
+@RestController
+public class FormController {
+
+    private final FormService formService;
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createForm(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @RequestBody FormCreateRequestDTO formCreateRequest){
+        formService.createForm(userId, formCreateRequest);
+        return SuccessResponse.created(null);
+    }
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormCreateRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormCreateRequestDTO.java
@@ -1,0 +1,9 @@
+package org.farmsystem.sotserver.domain.form.dto.request;
+
+import java.util.List;
+
+public record FormCreateRequestDTO(
+        Long articleId,
+        List<String> formQuestions
+) {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormQuestionResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormQuestionResponseDTO.java
@@ -1,0 +1,11 @@
+package org.farmsystem.sotserver.domain.form.dto.response;
+
+public record FormQuestionResponseDTO(
+        int questionOrder,
+        String questionContent
+
+) {
+    public static FormQuestionResponseDTO of(int questionOrder, String questionContent) {
+        return new FormQuestionResponseDTO(questionOrder, questionContent);
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/Answer.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/Answer.java
@@ -1,0 +1,23 @@
+package org.farmsystem.sotserver.domain.form.entity;
+
+import jakarta.persistence.*;
+import org.farmsystem.sotserver.domain.user.entity.User;
+
+@Entity
+public class Answer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long answerId;
+
+    private String answerContent;
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private FormQuestion question;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -16,6 +16,7 @@ import org.farmsystem.sotserver.global.common.BaseTimeEntity;
 @Entity
 public class AnswerForm extends BaseTimeEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long applicationId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/Form.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/Form.java
@@ -9,6 +9,9 @@ import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.global.common.BaseTimeEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @AllArgsConstructor
 @Builder
 @Getter
@@ -16,17 +19,44 @@ import org.farmsystem.sotserver.global.common.BaseTimeEntity;
 @Table(name = "form")
 @Entity
 public class Form extends BaseTimeEntity {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long formId;
 
-    @Enumerated(EnumType.STRING)
-    private FormStatus formStatus;
-
-    @ManyToOne
-    @JoinColumn(name = "article_id")
+    @OneToOne
+    @JoinColumn(name = "article_id", unique = true, nullable = false)
     private Article article;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    // Form에서 질문 리스트 조회 위한 양방향 매핑 추가
+    @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FormQuestion> questions;
+
+    //기본 질문을 포함한 Form 생성
+    public static Form createWithDefaultQuestions(Article article, User user) {
+        Form form = Form.builder()
+                .article(article)
+                .user(user)
+                .questions(new ArrayList<>())
+                .build();
+
+        form.addQuestion("이름", 0);
+        form.addQuestion("연락처", 1);
+        return form;
+    }
+
+    // 커스텀 질문 추가
+    public void addQuestion(String content, int order) {
+        FormQuestion question = FormQuestion.builder()
+                .questionContent(content)
+                .questionOrder(order)
+                .form(this)
+                .build();
+        this.questions.add(question);
+    }
+
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/FormQuestion.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/FormQuestion.java
@@ -14,10 +14,15 @@ import lombok.NoArgsConstructor;
 @Entity
 public class FormQuestion {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long questionId;
 
-    @ManyToOne
-    @JoinColumn(name = "form_id")
+    private String questionContent;
+
+    private int questionOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "form_id", nullable = false)
     private Form form;
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormQuestionRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormQuestionRepository.java
@@ -1,0 +1,7 @@
+package org.farmsystem.sotserver.domain.form.repository;
+
+import org.farmsystem.sotserver.domain.form.entity.FormQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormQuestionRepository extends JpaRepository<FormQuestion, Long> {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
@@ -1,0 +1,9 @@
+package org.farmsystem.sotserver.domain.form.repository;
+
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.form.entity.Form;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FormRepository extends JpaRepository<Form, Long> {
+    boolean existsByArticle(Article article);
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -1,0 +1,49 @@
+package org.farmsystem.sotserver.domain.form.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
+import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.entity.Form;
+import org.farmsystem.sotserver.domain.form.repository.FormRepository;
+import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.global.error.exception.ConflictException;
+import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
+import org.farmsystem.sotserver.global.error.exception.ForbiddenException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.*;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class FormService {
+
+    private final ArticleRepository articleRepository;
+    private final FormRepository formRepository;
+
+    // 폼 생성 (질문 생성)
+    public void createForm(Long userId, FormCreateRequestDTO formCreateRequest) {
+        Article article = articleRepository.findById(formCreateRequest.articleId())
+                .orElseThrow(() -> new EntityNotFoundException(ARTICLE_NOT_FOUND));
+
+        User author = article.getAuthor();
+        if (!author.getUserId().equals(userId)) {
+            throw new ForbiddenException(ARTICLE_AUTHOR_ONLY_FORM_CREATION);
+        }
+
+        if (formRepository.existsByArticle(article)) {
+            throw new ConflictException(ARTICLE_FORM_ALREADY_EXISTS);
+        }
+
+        Form form = Form.createWithDefaultQuestions(article, author);
+
+        int order = 2;
+        for (String question : formCreateRequest.formQuestions()) {
+            form.addQuestion(question, order++);
+        }
+
+        formRepository.save(form);
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
 import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.farmsystem.sotserver.domain.form.repository.FormRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
@@ -12,6 +13,8 @@ import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
 import org.farmsystem.sotserver.global.error.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.farmsystem.sotserver.global.error.ErrorCode.*;
 
@@ -45,5 +48,15 @@ public class FormService {
         }
 
         formRepository.save(form);
+    }
+
+    // 폼 질문 조회
+    public List<FormQuestionResponseDTO> getFormQuestions(Long userId, Long formId) {
+        Form form = formRepository.findById(formId)
+                .orElseThrow(() -> new EntityNotFoundException(FORM_NOT_FOUND));
+
+        return form.getQuestions().stream()
+                .map(question -> FormQuestionResponseDTO.of(question.getQuestionOrder(), question.getQuestionContent()))
+                .toList();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
@@ -1,13 +1,13 @@
 package org.farmsystem.sotserver.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
-
-import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.sotserver.domain.user.dto.request.ProfileUpdateRequestDTO;
 import org.farmsystem.sotserver.domain.user.service.UserService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,4 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class UserController {
     private final UserService userService;
+
+
+    //마이페이지 수정
+    @PatchMapping("/my-page")
+    public ResponseEntity<SuccessResponse<?>> updateProfile(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @ModelAttribute ProfileUpdateRequestDTO profileUpdateRequest
+    ) {
+        userService.updateProfile(userId, profileUpdateRequest);
+        return SuccessResponse.ok(null);
+    }
+
+
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
-
     //마이페이지 수정
     @PatchMapping("/my-page")
     public ResponseEntity<SuccessResponse<?>> updateProfile(

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/ProfileUpdateRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/ProfileUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record ProfileUpdateRequestDTO(
+    MultipartFile profileImage,
+    String introduction,
+    List<String> talent,
+    List<String> skill
+) {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -18,13 +18,26 @@ public class User {
     private String imageUrl;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Role role;
+
+    @Column(length = 500)
+    private String introduction;
+
+    //파싱해서 사용(임시)
+    private String skills;
+    private String talents;
 
     public User(String socialId, String imageUrl, Role role) {
         this.socialId = socialId;
         this.imageUrl = imageUrl;
         this.role = role;
     }
+
+    public void updateProfileImage(String imageUrl) {this.imageUrl = imageUrl;}
+    public void updateIntroduction(String introduction) {this.introduction = introduction;}
+    public void updateSkills(String skills) {this.skills = skills;}
+    public void updateTalents(String talents) {this.talents = talents;}
 
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -2,14 +2,26 @@ package org.farmsystem.sotserver.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.farmsystem.sotserver.domain.user.dto.request.ProfileUpdateRequestDTO;
 import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
 import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.sotserver.domain.user.entity.Role;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
+import org.farmsystem.sotserver.global.s3.S3Uploader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.FILE_UPLOAD_FAILED;
+import static org.farmsystem.sotserver.global.error.ErrorCode.USER_NOT_FOUND;
 
 
 @RequiredArgsConstructor
@@ -18,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
+    private final S3Uploader s3Uploader;
 
     public User saveUser(String socialId, String imageUrl, UserLoginRequestDTO request) {
         return userRepository.findBySocialId(socialId)
@@ -30,5 +43,31 @@ public class UserService {
     public UserTokenResponseDTO issueTempToken(Long userId) {
         String accessToken = jwtProvider.getIssueToken(userId, true);
         return UserTokenResponseDTO.of(accessToken);
+    }
+
+    // 마이페이지 수정
+    public void updateProfile(Long userId, ProfileUpdateRequestDTO profileUpdateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        MultipartFile image = profileUpdateRequest.profileImage();
+        String introduction = profileUpdateRequest.introduction();
+        List<String> skills = Optional.ofNullable(profileUpdateRequest.skill()).orElse(List.of());
+        List<String> talents = Optional.ofNullable(profileUpdateRequest.talent()).orElse(List.of());
+
+        if (image != null && !image.isEmpty() ) {user.updateProfileImage(uploadProfileImage(image));}
+        if (introduction != null) {user.updateIntroduction(introduction);}
+        // 리스트를 콤마로 구분하여 문자열로 변환
+        if (!skills.isEmpty()) {user.updateSkills(String.join(",", skills));}
+        if (!talents.isEmpty()) {user.updateTalents(String.join(",", talents));}
+    }
+
+    private String uploadProfileImage(MultipartFile profileImage) {
+        try {
+            String key = s3Uploader.upload(profileImage, "profile-images");
+            return s3Uploader.getFileUrl(key);
+        } catch (IOException e) {
+            throw new BusinessException(FILE_UPLOAD_FAILED);
+        }
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -66,6 +66,13 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "다른 소셜 계정으로 이미 가입된 사용자입니다."),
 
+    /**
+     * Article Error
+     */
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    ARTICLE_AUTHOR_ONLY_FORM_CREATION(HttpStatus.FORBIDDEN, "게시물 작성자만 폼을 생성할 수 있습니다."),
+    ARTICLE_FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 게시물에 대한 질문폼이 존재합니다.")
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -71,8 +71,12 @@ public enum ErrorCode {
      */
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
     ARTICLE_AUTHOR_ONLY_FORM_CREATION(HttpStatus.FORBIDDEN, "게시물 작성자만 폼을 생성할 수 있습니다."),
-    ARTICLE_FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 게시물에 대한 질문폼이 존재합니다.")
+    ARTICLE_FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 게시물에 대한 질문폼이 존재합니다."),
 
+    /**
+     * Form Error
+     */
+    FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 질문폼을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
      * 500 Internal Server Error
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 중 오류가 발생했습니다."),
 
     /**
      * Oauth Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #7
 
## 🌱 작업 사항
- 마이페이지 수정 API
- 폼 질문 생성 API 
- 폼 질문 리스트 조회 API 

## 🌱 참고 사항
- erd 짰던대로 Article-Form 매핑 1대1로 수정했고 Answer테이블이 없어서 새로 만들었습니당 (요거 바탕으로 지원폼도 짤게요 작업 중이었으면 develop에서 엔티티 땡겨오시면 될 거 같슴다)
- TODO : @PreAuthorize 권한 관련해서 헷갈리는 부분이있어서 안넣었는데 나중에 추가 예정입니다