### PR TITLE
[feat] 지원폼 상태 변경 & 리스트 조회 API 구현

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/controller/ArticleController.java
@@ -2,7 +2,11 @@ package org.farmsystem.sotserver.domain.article.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.sotserver.domain.article.dto.*;
+import org.farmsystem.sotserver.domain.article.dto.request.ArticleCreateRequest;
+import org.farmsystem.sotserver.domain.article.dto.request.ArticleStatusRequest;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleCreateResponse;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleDetailResponse;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleListResponse;
 import org.farmsystem.sotserver.domain.article.service.ArticleService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
 import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/request/ArticleCreateRequest.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/request/ArticleCreateRequest.java
@@ -1,4 +1,4 @@
-package org.farmsystem.sotserver.domain.article.dto;
+package org.farmsystem.sotserver.domain.article.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/request/ArticleStatusRequest.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/request/ArticleStatusRequest.java
@@ -1,4 +1,4 @@
-package org.farmsystem.sotserver.domain.article.dto;
+package org.farmsystem.sotserver.domain.article.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleCreateResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleCreateResponse.java
@@ -1,4 +1,4 @@
-package org.farmsystem.sotserver.domain.article.dto;
+package org.farmsystem.sotserver.domain.article.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleDetailResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleDetailResponse.java
@@ -1,10 +1,11 @@
-package org.farmsystem.sotserver.domain.article.dto;
+package org.farmsystem.sotserver.domain.article.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.Builder;
+import lombok.Getter;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
+import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
 
 import java.time.LocalDateTime;
@@ -13,7 +14,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Builder
-public class ArticleListResponse {
+public class ArticleDetailResponse {
     private Long id;
     private String title;
     private String content;
@@ -23,23 +24,22 @@ public class ArticleListResponse {
     private LocalDateTime updateAt;
     private List<String> imageUrls;
 
-    // 댓글 개수 필드
-    private int commentCount;
+    // 댓글 정보 필드 추가
+    private List<CommentResponse> comments;
 
-    // 팩토리 메서드
-    public static ArticleListResponse from(Article article, S3Uploader s3Uploader, int commentCount) {
-        return ArticleListResponse.builder()
+    public static ArticleDetailResponse from(Article article, S3Uploader s3Uploader, List<CommentResponse> comments) {
+        return ArticleDetailResponse.builder()
                 .id(article.getArticleId())
                 .title(article.getTitle())
                 .content(article.getContent())
-                .status(article.getStatus())
                 .userId(article.getAuthor().getUserId())
+                .status(article.getStatus())
                 .createAt(article.getCreatedAt())
                 .updateAt(article.getUpdatedAt())
                 .imageUrls(article.getImages().stream()
                         .map(img -> s3Uploader.getFileUrl(img.getKey()))
                         .toList())
-                .commentCount(commentCount)
+                .comments(comments)
                 .build();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleListResponse.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/ArticleListResponse.java
@@ -1,11 +1,10 @@
-package org.farmsystem.sotserver.domain.article.dto;
+package org.farmsystem.sotserver.domain.article.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.Builder;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
-import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
 
 import java.time.LocalDateTime;
@@ -14,7 +13,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Builder
-public class ArticleDetailResponse {
+public class ArticleListResponse {
     private Long id;
     private String title;
     private String content;
@@ -24,22 +23,23 @@ public class ArticleDetailResponse {
     private LocalDateTime updateAt;
     private List<String> imageUrls;
 
-    // 댓글 정보 필드 추가
-    private List<CommentResponse> comments;
+    // 댓글 개수 필드
+    private int commentCount;
 
-    public static ArticleDetailResponse from(Article article, S3Uploader s3Uploader, List<CommentResponse> comments) {
-        return ArticleDetailResponse.builder()
+    // 팩토리 메서드
+    public static ArticleListResponse from(Article article, S3Uploader s3Uploader, int commentCount) {
+        return ArticleListResponse.builder()
                 .id(article.getArticleId())
                 .title(article.getTitle())
                 .content(article.getContent())
-                .userId(article.getAuthor().getUserId())
                 .status(article.getStatus())
+                .userId(article.getAuthor().getUserId())
                 .createAt(article.getCreatedAt())
                 .updateAt(article.getUpdatedAt())
                 .imageUrls(article.getImages().stream()
                         .map(img -> s3Uploader.getFileUrl(img.getKey()))
                         .toList())
-                .comments(comments)
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
@@ -1,7 +1,11 @@
 package org.farmsystem.sotserver.domain.article.service;
 
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.sotserver.domain.article.dto.*;
+import org.farmsystem.sotserver.domain.article.dto.request.ArticleCreateRequest;
+import org.farmsystem.sotserver.domain.article.dto.request.ArticleStatusRequest;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleCreateResponse;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleDetailResponse;
+import org.farmsystem.sotserver.domain.article.dto.response.ArticleListResponse;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
 import org.farmsystem.sotserver.domain.article.entity.Image;

--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -39,22 +39,32 @@ public class FormController {
         return SuccessResponse.ok(formQuestions);
     }
 
-    // 지원폼 수락/거절
-    @PatchMapping
-    public ResponseEntity<SuccessResponse<?>> acceptForm(
-            @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody FormStatusRequestDTO formStatusRequest) {
-        formService.updateFormStatus(userId, formStatusRequest);
-        return SuccessResponse.ok(null);
-
-    }
-
     // 지원폼 목록 조회
-    @GetMapping("/{formId}")
+    @GetMapping("/{formId}/")
     public ResponseEntity<SuccessResponse<?>> getFormApplications(
             @AuthenticationPrincipal(expression = "userId") Long userId) {
         List<FormApplicationResponseDTO> formApplications = formService.getFormApplications(userId);
         return SuccessResponse.ok(formApplications);
+    }
+
+    // 지원폼 수락/거절
+    @PatchMapping("/application/{applicationId}/status")
+    public ResponseEntity<SuccessResponse<?>> acceptForm(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long applicationId,
+            @RequestBody FormStatusRequestDTO formStatusRequest) {
+        formService.updateFormStatus(userId, applicationId, formStatusRequest);
+        return SuccessResponse.ok(null);
+
+    }
+
+    // 지원폼 열람
+    @PatchMapping("/application/{applicationId}/read")
+    public ResponseEntity<SuccessResponse<?>> readFormApplication(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long applicationId) {
+        formService.readFormApplication(userId, applicationId);
+        return SuccessResponse.ok(null);
     }
 
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -40,10 +40,12 @@ public class FormController {
     }
 
     // 지원폼 목록 조회
-    @GetMapping("/{formId}/")
+    @GetMapping("/{formId}")
     public ResponseEntity<SuccessResponse<?>> getFormApplications(
-            @AuthenticationPrincipal(expression = "userId") Long userId) {
-        List<FormApplicationResponseDTO> formApplications = formService.getFormApplications(userId);
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long formId
+    ) {
+        List<FormApplicationResponseDTO> formApplications = formService.getFormApplications(userId, formId);
         return SuccessResponse.ok(formApplications);
     }
 
@@ -55,7 +57,6 @@ public class FormController {
             @RequestBody FormStatusRequestDTO formStatusRequest) {
         formService.updateFormStatus(userId, applicationId, formStatusRequest);
         return SuccessResponse.ok(null);
-
     }
 
     // 지원폼 열람

--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -3,6 +3,7 @@ package org.farmsystem.sotserver.domain.form.controller;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.FormApplicationResponseDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
 import org.farmsystem.sotserver.domain.form.service.FormService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
@@ -38,7 +39,7 @@ public class FormController {
         return SuccessResponse.ok(formQuestions);
     }
 
-    // 폼 수락/거절
+    // 지원폼 수락/거절
     @PatchMapping
     public ResponseEntity<SuccessResponse<?>> acceptForm(
             @AuthenticationPrincipal(expression = "userId") Long userId,
@@ -46,6 +47,14 @@ public class FormController {
         formService.updateFormStatus(userId, formStatusRequest);
         return SuccessResponse.ok(null);
 
+    }
+
+    // 지원폼 목록 조회
+    @GetMapping("/{formId}")
+    public ResponseEntity<SuccessResponse<?>> getFormApplications(
+            @AuthenticationPrincipal(expression = "userId") Long userId) {
+        List<FormApplicationResponseDTO> formApplications = formService.getFormApplications(userId);
+        return SuccessResponse.ok(formApplications);
     }
 
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/controller/FormController.java
@@ -2,6 +2,7 @@ package org.farmsystem.sotserver.domain.form.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
 import org.farmsystem.sotserver.domain.form.service.FormService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
@@ -35,6 +36,16 @@ public class FormController {
             @PathVariable Long formId ) {
         List<FormQuestionResponseDTO> formQuestions = formService.getFormQuestions(userId, formId);
         return SuccessResponse.ok(formQuestions);
+    }
+
+    // 폼 수락/거절
+    @PatchMapping
+    public ResponseEntity<SuccessResponse<?>> acceptForm(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @RequestBody FormStatusRequestDTO formStatusRequest) {
+        formService.updateFormStatus(userId, formStatusRequest);
+        return SuccessResponse.ok(null);
+
     }
 
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormStatusRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormStatusRequestDTO.java
@@ -3,7 +3,6 @@ package org.farmsystem.sotserver.domain.form.dto.request;
 import org.farmsystem.sotserver.domain.form.entity.FormStatus;
 
 public record FormStatusRequestDTO (
-    Long applicationId,
-    FormStatus formStatus
+        FormStatus formStatus
 ){
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormStatusRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/request/FormStatusRequestDTO.java
@@ -1,0 +1,9 @@
+package org.farmsystem.sotserver.domain.form.dto.request;
+
+import org.farmsystem.sotserver.domain.form.entity.FormStatus;
+
+public record FormStatusRequestDTO (
+    Long applicationId,
+    FormStatus formStatus
+){
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormApplicationResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormApplicationResponseDTO.java
@@ -13,8 +13,8 @@ public record FormApplicationResponseDTO(
         String createdDate,
         FormStatus formStatus,
         ReadStatus readStatus,
-        String imageUrl,
         String nickname,
+        String imageUrl,
         List<String> skills,
         List<String> talents
 ) {
@@ -26,8 +26,8 @@ public record FormApplicationResponseDTO(
                 formattedDate,
                 answerForm.getFormStatus(),
                 answerForm.getReadStatus(),
-                user.getImageUrl(),
                 user.getNickname(),
+                user.getImageUrl(),
                 user.getParsedList(user.getSkills()),
                 user.getParsedList(user.getTalents())
         );

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormApplicationResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/FormApplicationResponseDTO.java
@@ -1,0 +1,35 @@
+package org.farmsystem.sotserver.domain.form.dto.response;
+
+import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
+import org.farmsystem.sotserver.domain.form.entity.FormStatus;
+import org.farmsystem.sotserver.domain.form.entity.ReadStatus;
+import org.farmsystem.sotserver.domain.user.entity.User;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record FormApplicationResponseDTO(
+        Long applicationId,
+        String createdDate,
+        FormStatus formStatus,
+        ReadStatus readStatus,
+        String imageUrl,
+        String nickname,
+        List<String> skills,
+        List<String> talents
+) {
+    public static FormApplicationResponseDTO from(AnswerForm answerForm, User user) {
+        String formattedDate = answerForm.getCreatedAt().format(DateTimeFormatter.ofPattern("MM.dd"));
+
+        return new FormApplicationResponseDTO(
+                answerForm.getApplicationId(),
+                formattedDate,
+                answerForm.getFormStatus(),
+                answerForm.getReadStatus(),
+                user.getImageUrl(),
+                user.getNickname(),
+                user.getParsedList(user.getSkills()),
+                user.getParsedList(user.getTalents())
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -36,5 +36,6 @@ public class AnswerForm extends BaseTimeEntity {
     public void updateFormStatus(FormStatus formStatus) {
         this.formStatus = formStatus;
     }
+    public void updateReadStatus(ReadStatus readStatus) {this.readStatus = readStatus;}
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -36,9 +36,7 @@ public class AnswerForm extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public void updateFormStatus(FormStatus formStatus) {
-        this.formStatus = formStatus;
-    }
+    public void updateFormStatus(FormStatus formStatus) {this.formStatus = formStatus;}
     public void updateReadStatus(ReadStatus readStatus) {this.readStatus = readStatus;}
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -20,8 +20,10 @@ public class AnswerForm extends BaseTimeEntity {
     private Long applicationId;
 
     @Enumerated(EnumType.STRING)
-
     private FormStatus formStatus = FormStatus.WAITING;
+
+    @Enumerated(EnumType.STRING)
+    private ReadStatus readStatus = ReadStatus.UNREAD;
 
     @ManyToOne
     @JoinColumn(name = "form_id")

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -20,7 +20,8 @@ public class AnswerForm extends BaseTimeEntity {
     private Long applicationId;
 
     @Enumerated(EnumType.STRING)
-    private FormStatus formStatus;
+
+    private FormStatus formStatus = FormStatus.WAITING;
 
     @ManyToOne
     @JoinColumn(name = "form_id")
@@ -29,5 +30,9 @@ public class AnswerForm extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void updateFormStatus(FormStatus formStatus) {
+        this.formStatus = formStatus;
+    }
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerForm.java
@@ -25,6 +25,9 @@ public class AnswerForm extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ReadStatus readStatus = ReadStatus.UNREAD;
 
+    @Enumerated(EnumType.STRING)
+    private AnswerFormStatus answerFormStatus = AnswerFormStatus.SAVING;
+
     @ManyToOne
     @JoinColumn(name = "form_id")
     private Form form;

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerFormStatus.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/AnswerFormStatus.java
@@ -1,0 +1,6 @@
+package org.farmsystem.sotserver.domain.form.entity;
+
+public enum AnswerFormStatus {
+    SAVING, //임시저장
+    SUBMITTED, //제출
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/ReadStatus.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/ReadStatus.java
@@ -1,0 +1,6 @@
+package org.farmsystem.sotserver.domain.form.entity;
+
+public enum ReadStatus {
+    UNREAD,
+    READ
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/ReadStatus.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/ReadStatus.java
@@ -1,6 +1,6 @@
 package org.farmsystem.sotserver.domain.form.entity;
 
 public enum ReadStatus {
-    UNREAD,
-    READ
+    UNREAD, //미열람
+    READ //열람
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
@@ -1,0 +1,8 @@
+package org.farmsystem.sotserver.domain.form.repository;
+
+import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerFormRepository extends JpaRepository<AnswerForm, Long> {
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
@@ -1,12 +1,12 @@
 package org.farmsystem.sotserver.domain.form.repository;
 
 import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
+import org.farmsystem.sotserver.domain.form.entity.AnswerFormStatus;
 import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AnswerFormRepository extends JpaRepository<AnswerForm, Long> {
-
-    List<AnswerForm> findAllByFormOrderByCreatedAtDesc(Form form);
+    List<AnswerForm> findAllByFormAndAnswerFormStatusOrderByCreatedAtDesc(Form form, AnswerFormStatus answerFormStatus);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
@@ -1,8 +1,12 @@
 package org.farmsystem.sotserver.domain.form.repository;
 
 import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
+import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface AnswerFormRepository extends JpaRepository<AnswerForm, Long> {
 
+    List<AnswerForm> findAllByFormOrderByCreatedAtDesc(Form form);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 
 public interface FormRepository extends JpaRepository<Form, Long> {
     boolean existsByArticle(Article article);
-
-    Optional<Form> findByUser_UserId(Long userId);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/FormRepository.java
@@ -4,6 +4,10 @@ import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FormRepository extends JpaRepository<Form, Long> {
     boolean existsByArticle(Article article);
+
+    Optional<Form> findByUser_UserId(Long userId);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -5,6 +5,7 @@ import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.FormApplicationResponseDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
 import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
 import org.farmsystem.sotserver.domain.form.entity.Form;
@@ -83,5 +84,18 @@ public class FormService {
         validateAuthor(userId, article);
 
         answerForm.updateFormStatus(formStatus);
+    }
+
+    // 지원폼 목록 조회
+    @Transactional(readOnly = true)
+    public List<FormApplicationResponseDTO> getFormApplications(Long userId) {
+        Form form = formRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException(FORM_NOT_FOUND));
+
+        List<AnswerForm> answerForms = answerFormRepository.findAllByFormOrderByCreatedAtDesc(form);
+
+        return answerForms.stream()
+                .map(answerForm -> FormApplicationResponseDTO.from(answerForm, answerForm.getUser()))
+                .toList();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -7,10 +7,7 @@ import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormApplicationResponseDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
-import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
-import org.farmsystem.sotserver.domain.form.entity.Form;
-import org.farmsystem.sotserver.domain.form.entity.FormStatus;
-import org.farmsystem.sotserver.domain.form.entity.ReadStatus;
+import org.farmsystem.sotserver.domain.form.entity.*;
 import org.farmsystem.sotserver.domain.form.repository.AnswerFormRepository;
 import org.farmsystem.sotserver.domain.form.repository.FormRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
@@ -63,6 +60,7 @@ public class FormService {
     }
 
     // 폼 질문 조회
+    @Transactional(readOnly = true)
     public List<FormQuestionResponseDTO> getFormQuestions(Long userId, Long formId) {
         Form form = formRepository.findById(formId)
                 .orElseThrow(() -> new EntityNotFoundException(FORM_NOT_FOUND));
@@ -74,17 +72,20 @@ public class FormService {
 
     // 지원폼 목록 조회
     @Transactional(readOnly = true)
-    public List<FormApplicationResponseDTO> getFormApplications(Long userId) {
-        Form form = formRepository.findByUser_UserId(userId)
+    public List<FormApplicationResponseDTO> getFormApplications(Long userId, Long formId) {
+        Form form = formRepository.findById(formId)
                 .orElseThrow(() -> new EntityNotFoundException(FORM_NOT_FOUND));
 
-        List<AnswerForm> answerForms = answerFormRepository.findAllByFormOrderByCreatedAtDesc(form);
+        Article article = form.getArticle();
+        validateAuthor(userId, article);
+
+        List<AnswerForm> answerForms = answerFormRepository
+                .findAllByFormAndAnswerFormStatusOrderByCreatedAtDesc(form, AnswerFormStatus.SUBMITTED);
 
         return answerForms.stream()
                 .map(answerForm -> FormApplicationResponseDTO.from(answerForm, answerForm.getUser()))
                 .toList();
     }
-
 
     // 지원폼 수락/거절
     public void updateFormStatus(Long userId, Long applicationId, FormStatusRequestDTO formStatusRequest) {

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.repository.ArticleRepository;
 import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
+import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
+import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
 import org.farmsystem.sotserver.domain.form.entity.Form;
+import org.farmsystem.sotserver.domain.form.entity.FormStatus;
+import org.farmsystem.sotserver.domain.form.repository.AnswerFormRepository;
 import org.farmsystem.sotserver.domain.form.repository.FormRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.global.error.exception.ConflictException;
@@ -25,6 +29,14 @@ public class FormService {
 
     private final ArticleRepository articleRepository;
     private final FormRepository formRepository;
+    private final AnswerFormRepository answerFormRepository;
+
+    // 작성자인지 검증
+    private void validateAuthor(Long userId, Article article) {
+        if (!article.getAuthor().getUserId().equals(userId)) {
+            throw new ForbiddenException(ARTICLE_AUTHOR_ONLY_ACTION);
+        }
+    }
 
     // 폼 생성 (질문 생성)
     public void createForm(Long userId, FormCreateRequestDTO formCreateRequest) {
@@ -32,9 +44,7 @@ public class FormService {
                 .orElseThrow(() -> new EntityNotFoundException(ARTICLE_NOT_FOUND));
 
         User author = article.getAuthor();
-        if (!author.getUserId().equals(userId)) {
-            throw new ForbiddenException(ARTICLE_AUTHOR_ONLY_FORM_CREATION);
-        }
+        validateAuthor(userId, article);
 
         if (formRepository.existsByArticle(article)) {
             throw new ConflictException(ARTICLE_FORM_ALREADY_EXISTS);
@@ -58,5 +68,20 @@ public class FormService {
         return form.getQuestions().stream()
                 .map(question -> FormQuestionResponseDTO.of(question.getQuestionOrder(), question.getQuestionContent()))
                 .toList();
+    }
+
+    // 폼 수락/거절
+    public void updateFormStatus(Long userId, FormStatusRequestDTO formStatusRequest) {
+        Long applicationId = formStatusRequest.applicationId();
+        FormStatus formStatus = formStatusRequest.formStatus();
+
+        AnswerForm answerForm = answerFormRepository.findById(applicationId)
+                .orElseThrow(() -> new EntityNotFoundException(ANSWER_FORM_NOT_FOUND));
+
+        Form form = answerForm.getForm();
+        Article article = form.getArticle();
+        validateAuthor(userId, article);
+
+        answerForm.updateFormStatus(formStatus);
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -10,6 +10,7 @@ import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO
 import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
 import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.farmsystem.sotserver.domain.form.entity.FormStatus;
+import org.farmsystem.sotserver.domain.form.entity.ReadStatus;
 import org.farmsystem.sotserver.domain.form.repository.AnswerFormRepository;
 import org.farmsystem.sotserver.domain.form.repository.FormRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
@@ -71,21 +72,6 @@ public class FormService {
                 .toList();
     }
 
-    // 폼 수락/거절
-    public void updateFormStatus(Long userId, FormStatusRequestDTO formStatusRequest) {
-        Long applicationId = formStatusRequest.applicationId();
-        FormStatus formStatus = formStatusRequest.formStatus();
-
-        AnswerForm answerForm = answerFormRepository.findById(applicationId)
-                .orElseThrow(() -> new EntityNotFoundException(ANSWER_FORM_NOT_FOUND));
-
-        Form form = answerForm.getForm();
-        Article article = form.getArticle();
-        validateAuthor(userId, article);
-
-        answerForm.updateFormStatus(formStatus);
-    }
-
     // 지원폼 목록 조회
     @Transactional(readOnly = true)
     public List<FormApplicationResponseDTO> getFormApplications(Long userId) {
@@ -97,5 +83,35 @@ public class FormService {
         return answerForms.stream()
                 .map(answerForm -> FormApplicationResponseDTO.from(answerForm, answerForm.getUser()))
                 .toList();
+    }
+
+
+    // 지원폼 수락/거절
+    public void updateFormStatus(Long userId, Long applicationId, FormStatusRequestDTO formStatusRequest) {
+        FormStatus formStatus = formStatusRequest.formStatus();
+
+        AnswerForm answerForm = answerFormRepository.findById(applicationId)
+                .orElseThrow(() -> new EntityNotFoundException(ANSWER_FORM_NOT_FOUND));
+
+        // 작성자인지 검증
+        Form form = answerForm.getForm();
+        Article article = form.getArticle();
+        validateAuthor(userId, article);
+
+        answerForm.updateFormStatus(formStatus);
+    }
+
+    // 지원폼 열람
+    public void readFormApplication(Long userId, Long applicationId) {
+        AnswerForm answerForm = answerFormRepository.findById(applicationId)
+                .orElseThrow(() -> new EntityNotFoundException(ANSWER_FORM_NOT_FOUND));
+
+        Form form = answerForm.getForm();
+        Article article = form.getArticle();
+        validateAuthor(userId, article);
+
+        if (answerForm.getReadStatus() == ReadStatus.UNREAD) {
+            answerForm.updateReadStatus(ReadStatus.READ);
+        }
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @Table(name = "user")
@@ -40,6 +42,12 @@ public class User {
     public void updateIntroduction(String introduction) {this.introduction = introduction;}
     public void updateSkills(String skills) {this.skills = skills;}
     public void updateTalents(String talents) {this.talents = talents;}
+
+    // 스트링 파싱 -> 리스트
+    public List<String> getParsedList(String value) {
+        if (value == null || value.isBlank()) return List.of();
+        return List.of(value.split(","));
+    }
 
 }
 

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -13,6 +13,8 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    private String nickname;
+
     private String socialId;
 
     private String imageUrl;

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -70,13 +70,14 @@ public enum ErrorCode {
      * Article Error
      */
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
-    ARTICLE_AUTHOR_ONLY_FORM_CREATION(HttpStatus.FORBIDDEN, "게시물 작성자만 폼을 생성할 수 있습니다."),
+    ARTICLE_AUTHOR_ONLY_ACTION(HttpStatus.FORBIDDEN, "게시글 작성자만 수행할 수 있는 작업입니다."),
     ARTICLE_FORM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 게시물에 대한 질문폼이 존재합니다."),
 
     /**
      * Form Error
      */
     FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 질문폼을 찾을 수 없습니다."),
+    ANSWER_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 답변폼을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #16 
 
## 🌱 작업 사항
- 지원폼 목록 조회 API 구현
- 지원폼 수락/거절 API 구현 
- 지원폼 열람 API 구현
- TODO : 작성자 권한 기능을 사용할 때 validateAuthor를 사용하는데 중복 코드가 좀 있어서 리팩토링 고민해보면 좋을 거 같습니다. 추가적인 권한, 지원상태 관련한 디테일한 예외처리 추가 필요

## 🌱 참고 사항
- 유저에 닉네임 필드, 지원폼에 임시저장/제출 여부, 열람 여부를 저장할 수 있는  enum 필드 추가했습니다. 
- 아티클 도메인 DTO들 request/response 패키지로 분리했습니다.
- 지원폼 수락/거절은 일단은 작성자가 정할 수 있게 구현했으나 기획에 따라 수정 필요할 거 같습니다(마감일 기준으로 거절할지, 인원 수 차면 거절할지 등) 
- 엔드포인트 관련해서 formId(질문폼 아이디) 이랑 applicationId(답변폼 아이디)가 구분되어야할 거 같은데 기존 엔드포인트 리소스간 계층관계 수정이 필요할 거 같아서 form이랑 application 리소스 간의 계층을 추가했습니다. => 엔드포인트 변경했다는 의미!
