### PR TITLE
[feat] 마이페이지 통합 조회 API 구현

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/MyArticleResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/dto/response/MyArticleResponseDTO.java
@@ -1,0 +1,27 @@
+package org.farmsystem.sotserver.domain.article.dto.response;
+
+import org.farmsystem.sotserver.domain.article.entity.Article;
+
+import java.time.format.DateTimeFormatter;
+
+public record MyArticleResponseDTO(
+        Long articleId,
+        String imageUrl,
+        String title,
+        String createdDate,
+        Long formId,
+        Boolean isAccepted // true(수락완료), false(지원자보기)
+) {
+    public static MyArticleResponseDTO from(Article article, Boolean isAccepted) {
+        String formattedDate = article.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        return new MyArticleResponseDTO(
+                article.getArticleId(),
+                article.getThumbnailImage(),
+                article.getTitle(),
+                formattedDate,
+                article.getForm().getFormId(),
+                isAccepted
+        );
+    }
+
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/article/entity/Article.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/entity/Article.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.farmsystem.sotserver.domain.form.entity.Form;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.global.common.BaseTimeEntity;
 
@@ -38,6 +39,9 @@ public class Article extends BaseTimeEntity {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
+    @OneToOne(mappedBy = "article")
+    private Form form;
+
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
@@ -45,5 +49,11 @@ public class Article extends BaseTimeEntity {
 
     public void changeStatus(ArticleStatus status) {
         this.status = status;
+    }
+
+    // 대표 이미지 가져오기(썸네일용)
+    @Transient
+    public String getThumbnailImage() {
+        return images.isEmpty() ? null : images.get(0).getKey();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/repository/ArticleRepository.java
@@ -1,8 +1,12 @@
 package org.farmsystem.sotserver.domain.article.repository;
 
 import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+    List<Article> findByAuthorOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/article/service/ArticleService.java
@@ -6,6 +6,7 @@ import org.farmsystem.sotserver.domain.article.dto.request.ArticleStatusRequest;
 import org.farmsystem.sotserver.domain.article.dto.response.ArticleCreateResponse;
 import org.farmsystem.sotserver.domain.article.dto.response.ArticleDetailResponse;
 import org.farmsystem.sotserver.domain.article.dto.response.ArticleListResponse;
+import org.farmsystem.sotserver.domain.article.dto.response.MyArticleResponseDTO;
 import org.farmsystem.sotserver.domain.article.entity.Article;
 import org.farmsystem.sotserver.domain.article.entity.ArticleStatus;
 import org.farmsystem.sotserver.domain.article.entity.Image;
@@ -14,8 +15,11 @@ import org.farmsystem.sotserver.domain.article.repository.ImageRepository;
 import org.farmsystem.sotserver.domain.comment.dto.CommentResponse;
 import org.farmsystem.sotserver.domain.comment.entity.Comment;
 import org.farmsystem.sotserver.domain.comment.repository.CommentRepository;
+import org.farmsystem.sotserver.domain.form.entity.Form;
+import org.farmsystem.sotserver.domain.form.entity.FormStatus;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.domain.user.repository.UserRepository;
+import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +30,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.farmsystem.sotserver.global.error.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -149,4 +155,27 @@ public class ArticleService {
             }
         }
     }
+
+    @Transactional(readOnly = true)
+    public List<MyArticleResponseDTO> getMyArticles(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        List<Article> articles = articleRepository.findByAuthorOrderByCreatedAtDesc(user);
+
+        return articles.stream()
+                .map(article -> {
+                    boolean isAccepted = articleHasApprovedAnswerForm(article);
+                    return MyArticleResponseDTO.from(article, isAccepted);
+                })
+                .toList();
+    }
+
+    //수락 완료인지 판별(임시용)
+    private boolean articleHasApprovedAnswerForm(Article article) {
+        Form form = article.getForm();
+        return form.getAnswerForms().stream()
+                .anyMatch(answerForm -> answerForm.getFormStatus() == FormStatus.APPROVED);
+    }
+
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/MyApplicationResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/MyApplicationResponseDTO.java
@@ -1,0 +1,28 @@
+package org.farmsystem.sotserver.domain.form.dto.response;
+
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
+import org.farmsystem.sotserver.domain.form.entity.AnswerFormStatus;
+
+import java.time.format.DateTimeFormatter;
+
+public record MyApplicationResponseDTO(
+        Long articleId,
+        String imageUrl,
+        String title,
+        Long applicationId,
+        String createdDate,
+        AnswerFormStatus answerFormStatus // SAVING(임시저장), SUBMITTED(제출완료)
+) {
+    public static MyApplicationResponseDTO from(Article article, AnswerForm answerForm){
+        String formattedDate = answerForm.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+        return new MyApplicationResponseDTO(
+                article.getArticleId(),
+                article.getThumbnailImage(),
+                article.getTitle(),
+                answerForm.getApplicationId(),
+                formattedDate,
+                answerForm.getAnswerFormStatus()
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/MyApplicationResultResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/dto/response/MyApplicationResultResponseDTO.java
@@ -1,0 +1,18 @@
+package org.farmsystem.sotserver.domain.form.dto.response;
+
+import org.farmsystem.sotserver.domain.article.entity.Article;
+import org.farmsystem.sotserver.domain.form.entity.FormStatus;
+
+public record MyApplicationResultResponseDTO(
+        Long articleId,
+        String imageUrl,
+        FormStatus formStatus // WAITING(지원완료), APPROVED(선정), REJECTED(미선정)
+){
+    public static MyApplicationResultResponseDTO from (Article article, FormStatus formStatus){
+        return new MyApplicationResultResponseDTO(
+                article.getArticleId(),
+                article.getThumbnailImage(),
+                formStatus
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/form/entity/Form.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/entity/Form.java
@@ -32,6 +32,9 @@ public class Form extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToMany(mappedBy = "form")
+    private List<AnswerForm> answerForms;
+
     // Form에서 질문 리스트 조회 위한 양방향 매핑 추가
     @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FormQuestion> questions;

--- a/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/repository/AnswerFormRepository.java
@@ -3,10 +3,13 @@ package org.farmsystem.sotserver.domain.form.repository;
 import org.farmsystem.sotserver.domain.form.entity.AnswerForm;
 import org.farmsystem.sotserver.domain.form.entity.AnswerFormStatus;
 import org.farmsystem.sotserver.domain.form.entity.Form;
+import org.farmsystem.sotserver.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AnswerFormRepository extends JpaRepository<AnswerForm, Long> {
     List<AnswerForm> findAllByFormAndAnswerFormStatusOrderByCreatedAtDesc(Form form, AnswerFormStatus answerFormStatus);
+
+    List<AnswerForm> findByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/form/service/FormService.java
@@ -7,10 +7,13 @@ import org.farmsystem.sotserver.domain.form.dto.request.FormCreateRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.request.FormStatusRequestDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormApplicationResponseDTO;
 import org.farmsystem.sotserver.domain.form.dto.response.FormQuestionResponseDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResponseDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResultResponseDTO;
 import org.farmsystem.sotserver.domain.form.entity.*;
 import org.farmsystem.sotserver.domain.form.repository.AnswerFormRepository;
 import org.farmsystem.sotserver.domain.form.repository.FormRepository;
 import org.farmsystem.sotserver.domain.user.entity.User;
+import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.error.exception.ConflictException;
 import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
 import org.farmsystem.sotserver.global.error.exception.ForbiddenException;
@@ -29,6 +32,7 @@ public class FormService {
     private final ArticleRepository articleRepository;
     private final FormRepository formRepository;
     private final AnswerFormRepository answerFormRepository;
+    private final UserRepository userRepository;
 
     // 작성자인지 검증
     private void validateAuthor(Long userId, Article article) {
@@ -114,5 +118,37 @@ public class FormService {
         if (answerForm.getReadStatus() == ReadStatus.UNREAD) {
             answerForm.updateReadStatus(ReadStatus.READ);
         }
+    }
+
+    //내 지원폼 결과보기 (제출 완료인 지원서 결과)
+    public List<MyApplicationResultResponseDTO> getMyApplicationResult(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new EntityNotFoundException(USER_NOT_FOUND));
+
+        //제출 완료인 지원서만 필터링
+        List<AnswerForm> submittedForms = answerFormRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                .filter(answerForm -> answerForm.getAnswerFormStatus()==AnswerFormStatus.SUBMITTED)
+                .toList();
+
+        return submittedForms.stream()
+                .map(answerForm -> {
+                    Article article = answerForm.getForm().getArticle();
+                    FormStatus status = answerForm.getFormStatus();
+                    return MyApplicationResultResponseDTO.from(article, status);
+                })
+                .toList();
+    }
+
+    //내 지원폼 보기(작성 중인 지원서 포함)
+    public List<MyApplicationResponseDTO> getMyApplications(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new EntityNotFoundException(USER_NOT_FOUND));
+
+        return answerFormRepository.findByUserOrderByCreatedAtDesc(user).stream()
+                .map(answerForm -> {
+                    Article article = answerForm.getForm().getArticle();
+                    return MyApplicationResponseDTO.from(article, answerForm);
+                })
+                .toList();
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
@@ -2,20 +2,28 @@ package org.farmsystem.sotserver.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.user.dto.request.ProfileUpdateRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.MypageResponseDTO;
 import org.farmsystem.sotserver.domain.user.service.UserService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
 @RestController
 public class UserController {
     private final UserService userService;
+
+    //마이페이지 조회
+    @GetMapping("/my-page")
+    public ResponseEntity<SuccessResponse<?>> getMyPage(
+            @AuthenticationPrincipal(expression = "userId") Long userId)
+    {
+        MypageResponseDTO myPage = userService.getMypage(userId);
+        return SuccessResponse.ok(myPage);
+    }
+
 
     //마이페이지 수정
     @PatchMapping("/my-page")
@@ -26,6 +34,4 @@ public class UserController {
         userService.updateProfile(userId, profileUpdateRequest);
         return SuccessResponse.ok(null);
     }
-
-
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/MyProfileResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/MyProfileResponseDTO.java
@@ -1,0 +1,27 @@
+package org.farmsystem.sotserver.domain.user.dto.response;
+
+import org.farmsystem.sotserver.domain.user.entity.User;
+
+import java.util.List;
+
+public record MyProfileResponseDTO(
+        Long userId,
+        String imageUrl,
+        String nickname,
+        String email,
+        String introduction,
+        List<String> talents,
+        List<String> skills
+) {
+    public static MyProfileResponseDTO from(User user) {
+        return new MyProfileResponseDTO(
+                user.getUserId(),
+                user.getImageUrl(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getIntroduction(),
+                user.getParsedList(user.getTalents()),
+                user.getParsedList(user.getSkills())
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/MypageResponseDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/response/MypageResponseDTO.java
@@ -1,0 +1,24 @@
+package org.farmsystem.sotserver.domain.user.dto.response;
+
+import org.farmsystem.sotserver.domain.article.dto.response.MyArticleResponseDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResponseDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResultResponseDTO;
+
+import java.util.List;
+
+public record MypageResponseDTO(
+        MyProfileResponseDTO myProfile,
+        List<MyApplicationResultResponseDTO> myApplicationResults,
+        List<MyApplicationResponseDTO> myApplications,
+        List<MyArticleResponseDTO> myArticles
+) {
+    public static MypageResponseDTO of( MyProfileResponseDTO myProfile, List<MyApplicationResultResponseDTO> myApplicationResults,
+                                        List<MyApplicationResponseDTO> myApplications, List<MyArticleResponseDTO> myArticles){
+        return new MypageResponseDTO(
+                myProfile,
+                myApplicationResults,
+                myApplications,
+                myArticles
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -17,6 +17,8 @@ public class User {
 
     private String nickname;
 
+    private String email;
+
     private String socialId;
 
     private String imageUrl;

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -1,9 +1,15 @@
 package org.farmsystem.sotserver.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-
+import org.farmsystem.sotserver.domain.article.dto.response.MyArticleResponseDTO;
+import org.farmsystem.sotserver.domain.article.service.ArticleService;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResponseDTO;
+import org.farmsystem.sotserver.domain.form.dto.response.MyApplicationResultResponseDTO;
+import org.farmsystem.sotserver.domain.form.service.FormService;
 import org.farmsystem.sotserver.domain.user.dto.request.ProfileUpdateRequestDTO;
 import org.farmsystem.sotserver.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.MyProfileResponseDTO;
+import org.farmsystem.sotserver.domain.user.dto.response.MypageResponseDTO;
 import org.farmsystem.sotserver.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.sotserver.domain.user.entity.Role;
 import org.farmsystem.sotserver.domain.user.entity.User;
@@ -31,6 +37,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final S3Uploader s3Uploader;
+    private final ArticleService articleService;
+    private final FormService formService;
 
     public User saveUser(String socialId, String imageUrl, UserLoginRequestDTO request) {
         return userRepository.findBySocialId(socialId)
@@ -69,5 +77,20 @@ public class UserService {
         } catch (IOException e) {
             throw new BusinessException(FILE_UPLOAD_FAILED);
         }
+    }
+
+    //마이페이지 조회
+    public MypageResponseDTO getMypage(Long userId) {
+        MyProfileResponseDTO myProfile = getMyProfile(userId);
+        List<MyApplicationResultResponseDTO> myApplicationResults = formService.getMyApplicationResult(userId);
+        List<MyApplicationResponseDTO> myApplications = formService.getMyApplications(userId);
+        List<MyArticleResponseDTO> myArticles = articleService.getMyArticles(userId);
+        return MypageResponseDTO.of(myProfile, myApplicationResults, myApplications, myArticles);
+    }
+
+    private MyProfileResponseDTO getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        return MyProfileResponseDTO.from(user);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #18
 
## 🌱 작업 사항
- 유저 테이블 이메일 필드 추가
- 마이페이지 구현(프로필 정보, 내가 지원한 글, 작성한 지원서, 내가 쓴 글 통합 조회)
   - 각각에 대한 조회 모듈은 도메인별로 분리해놨고 조회는 같이 조회합니다. 성능상 이슈가 있다 싶으면 분리할게요
<img width="610" alt="스크린샷 2025-05-28 15 58 24" src="https://github.com/user-attachments/assets/3ffe9036-a6f0-4951-830f-e11cdd212079" />

## 🌱 참고 사항
- 아티클마다 이미지를 여러 개 가질 수 있는데 이걸 다 가져오자니 list의 list여서,,,이 중 하나만 가져오는 getThumbnailImage함수 추가했습니다 (게시물 조회에서도 필요하면 활용해도 될 거 같아요)
 - enum 처리 어디까지 해줘야할 지 고민. 프론트에서 처리할 수 있는 raw한 형식으로 주라고 배우긴했는데 아예 다 enum으로 넘겨도 될지 모르겠어서 의견 있으시면,,,달아주세요

- 추후 수정 고려 
   - 수락 인원? 마감 기준에 대한 기획 확정되면 API 좀 수정 필요할 거 같슴다
   - 짜다보니 form 테이블의 역할이 약간 모호하다고 느낌 (상태를 관리해주는 것도 아니고 단순 중간 테이블 역할이어서... 의미도 애매하고, article테이블이랑 정합성 문제도 우려됨. 흠나중에 시간되면 없애거나 상태관리는 아예 article->form으로 넘기면 좋을 거 같아요!)
