### PR TITLE
[feat] 가입 시 이메일 인증 및 닉네임 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 
     // s3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.641'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/EmailAuthController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/EmailAuthController.java
@@ -1,0 +1,42 @@
+package org.farmsystem.sotserver.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.domain.user.dto.request.EmailRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.request.VerifyEmailRequestDTO;
+import org.farmsystem.sotserver.domain.user.service.MailService;
+import org.farmsystem.sotserver.domain.user.service.UserService;
+import org.farmsystem.sotserver.global.common.SuccessResponse;
+import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;
+import org.farmsystem.sotserver.global.error.ErrorCode;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth/email")
+@RequiredArgsConstructor
+public class EmailAuthController {
+
+    private final MailService mailService;
+    private final UserService userService;
+
+    @PostMapping("/send")
+    public ResponseEntity<SuccessResponse<?>> sendEmailAuthCode(@RequestBody @Valid EmailRequestDTO request) {
+        mailService.sendEmailAuthCode(request.email());
+        return SuccessResponse.ok("인증번호 전송 완료");
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<SuccessResponse<?>> verifyEmailCode(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid VerifyEmailRequestDTO request
+    ) {
+        mailService.verifyAuthCode(request.email(), request.code());
+        userService.verifyUserEmail(userDetails.getUserId(), request.email());
+        return SuccessResponse.ok("이메일 인증 성공");
+    }
+
+}
+

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/EmailAuthController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/EmailAuthController.java
@@ -23,10 +23,19 @@ public class EmailAuthController {
     private final UserService userService;
 
     @PostMapping("/send")
-    public ResponseEntity<SuccessResponse<?>> sendEmailAuthCode(@RequestBody @Valid EmailRequestDTO request) {
+    public ResponseEntity<SuccessResponse<?>> sendEmailAuthCode(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid EmailRequestDTO request
+    ) {
+        // 이메일 업데이트
+        userService.updateEmail(userDetails.getUserId(), request.email());
+
+        // 이메일 인증 코드 발송
         mailService.sendEmailAuthCode(request.email());
+
         return SuccessResponse.ok("인증번호 전송 완료");
     }
+
 
     @PostMapping("/verify")
     public ResponseEntity<SuccessResponse<?>> verifyEmailCode(

--- a/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/controller/UserController.java
@@ -2,9 +2,11 @@ package org.farmsystem.sotserver.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.sotserver.domain.user.dto.request.ProfileUpdateRequestDTO;
+import org.farmsystem.sotserver.domain.user.dto.request.UpdateNicknameRequest;
 import org.farmsystem.sotserver.domain.user.dto.response.MypageResponseDTO;
 import org.farmsystem.sotserver.domain.user.service.UserService;
 import org.farmsystem.sotserver.global.common.SuccessResponse;
+import org.farmsystem.sotserver.global.config.auth.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +34,14 @@ public class UserController {
             @ModelAttribute ProfileUpdateRequestDTO profileUpdateRequest
     ) {
         userService.updateProfile(userId, profileUpdateRequest);
+        return SuccessResponse.ok(null);
+    }
+
+    // 닉네임 수정 (최초 회원가입 시에도 사용)
+    @PatchMapping("/nickname")
+    public ResponseEntity<SuccessResponse<?>> updateNickname(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                @RequestBody UpdateNicknameRequest request) {
+        userService.updateNickname(userDetails.getUserId(), request.nickname());
         return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/EmailRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/EmailRequestDTO.java
@@ -1,0 +1,10 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailRequestDTO(
+        @NotBlank
+        @Email
+        String email
+) {}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,8 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateNicknameRequest(
+        @NotBlank String nickname
+) {
+}

--- a/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/VerifyEmailRequestDTO.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/dto/request/VerifyEmailRequestDTO.java
@@ -1,0 +1,10 @@
+package org.farmsystem.sotserver.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record VerifyEmailRequestDTO(
+        @NotBlank @Email String email,
+        @NotBlank String code
+) {}
+

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -46,6 +46,8 @@ public class User {
     public void updateTalents(String talents) {this.talents = talents;}
     public void updateRole(Role newRole) {this.role = newRole;}
     public void updateEmail(String email) {this.email = email;}
+    public void updateNickname(String nickname) {this.nickname = nickname;}
+
 
     // 스트링 파싱 -> 리스트
     public List<String> getParsedList(String value) {

--- a/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/entity/User.java
@@ -44,6 +44,8 @@ public class User {
     public void updateIntroduction(String introduction) {this.introduction = introduction;}
     public void updateSkills(String skills) {this.skills = skills;}
     public void updateTalents(String talents) {this.talents = talents;}
+    public void updateRole(Role newRole) {this.role = newRole;}
+    public void updateEmail(String email) {this.email = email;}
 
     // 스트링 파싱 -> 리스트
     public List<String> getParsedList(String value) {

--- a/src/main/java/org/farmsystem/sotserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findBySocialId(String socialId);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/MailService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/MailService.java
@@ -1,0 +1,52 @@
+package org.farmsystem.sotserver.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.sotserver.global.error.ErrorCode;
+import org.farmsystem.sotserver.global.error.exception.BusinessException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final String SUBJECT = "[SOT] 이메일 인증번호입니다.";
+
+    public void sendEmailAuthCode(String email) {
+        String authCode = generateAuthCode();
+        sendMail(email, authCode);
+        // TTL 설정
+        redisTemplate.opsForValue().set("email:auth:" + email, authCode, Duration.ofMinutes(5));
+    }
+
+    private void sendMail(String to, String authCode) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(SUBJECT);
+        message.setText("인증번호는 [" + authCode + "] 입니다. 5분 내로 입력해주세요.");
+        mailSender.send(message);
+    }
+
+    private String generateAuthCode() {
+        return String.valueOf((int) ((Math.random() * 900000) + 100000)); // 6자리 숫자
+    }
+
+    public boolean verifyAuthCode(String email, String inputCode) {
+        String redisKey = "email:auth:" + email;
+        String storedCode = redisTemplate.opsForValue().get(redisKey);
+
+        if (storedCode == null || !storedCode.equals(inputCode)) {
+            throw new BusinessException(ErrorCode.INVALID_AUTH_CODE);
+        }
+        return true;
+    }
+
+}
+

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/OauthService.java
@@ -44,7 +44,4 @@ public class OauthService {
 
     }
 
-
-
-
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -18,6 +18,7 @@ import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
 import org.farmsystem.sotserver.global.error.ErrorCode;
 import org.farmsystem.sotserver.global.error.exception.BusinessException;
 import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
+import org.farmsystem.sotserver.global.error.exception.UnauthorizedException;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -111,6 +112,19 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
         user.updateEmail(email);
+    }
+
+    // 닉네임 수정 (회원가입 시)
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        if (!user.getRole().equals(Role.ROLE_USER)) {
+            throw new UnauthorizedException(ErrorCode.ROLE_USER_ONLY);
+        }
+
+        user.updateNickname(newNickname);
     }
 
 }

--- a/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/sotserver/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import org.farmsystem.sotserver.domain.user.entity.Role;
 import org.farmsystem.sotserver.domain.user.entity.User;
 import org.farmsystem.sotserver.domain.user.repository.UserRepository;
 import org.farmsystem.sotserver.global.config.auth.jwt.JwtProvider;
+import org.farmsystem.sotserver.global.error.ErrorCode;
 import org.farmsystem.sotserver.global.error.exception.BusinessException;
 import org.farmsystem.sotserver.global.error.exception.EntityNotFoundException;
 import org.farmsystem.sotserver.global.s3.S3Uploader;
@@ -93,4 +94,23 @@ public class UserService {
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
         return MyProfileResponseDTO.from(user);
     }
+
+    // 이메일 인증
+    @Transactional
+    public void verifyUserEmail(Long userId, String email) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        if (!email.equals(user.getEmail())) {throw new BusinessException(ErrorCode.EMAIL_MISMATCH);}
+        user.updateRole(Role.ROLE_USER);
+    }
+
+    // 이메일 수정
+    @Transactional
+    public void updateEmail(Long userId, String email) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        user.updateEmail(email);
+    }
+
 }

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/ExceptionHandlerFilter.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/ExceptionHandlerFilter.java
@@ -26,9 +26,11 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (UnauthorizedException e) {
             handleUnauthorizedException(response, e);
-        } catch (Exception ee) {
+        } catch (Exception e) {
+            log.error("Unhandled exception in filter: {}", e.getMessage(), e);
             handleException(response);
         }
+
     }
 
     private void handleUnauthorizedException(HttpServletResponse response, Exception e) throws IOException {

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtProvider.java
@@ -97,6 +97,4 @@ public class JwtProvider {
         ).get("sub").toString();
     }
 
-
-
 }

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -65,6 +65,8 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "다른 소셜 계정으로 이미 가입된 사용자입니다."),
+    INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 코드입니다."),
+    EMAIL_MISMATCH(HttpStatus.NOT_FOUND, "이메일이 일치하지 않습니다"),
 
     /**
      * Article Error

--- a/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/sotserver/global/error/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "다른 소셜 계정으로 이미 가입된 사용자입니다."),
     INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 코드입니다."),
     EMAIL_MISMATCH(HttpStatus.NOT_FOUND, "이메일이 일치하지 않습니다"),
+    ROLE_USER_ONLY(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
 
     /**
      * Article Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #21 
 
## 🌱 작업 사항
application.yml 수정사항 있음 (6.29)

아래와 같은 순서로 로직 구성
1. 소셜로그인 완료 -> `ROLE_PENDING`
2. 이메일 입력 후 인증번호 요청 -> 해당 유저의 email 필드가 업데이트됨 *유효 시간 5분* -> 프론트 시간 반영 필요 (피그마 댓글 달아놓았습니다)
3. 이메일 인증번호 입력 후 인증 요청 -> email을 기준으로 유저를 찾고, 해당 유저의 권한을 ROLE_USER로 업데이트
4. ROLE_USER라면 닉네임 수정 요청 가능 ('가입하고 시작하기' 버튼)

## 🌱 참고 사항
아래의 사진 참고
<img width="277" alt="스크린샷 2025-06-29 오전 12 04 50" src="https://github.com/user-attachments/assets/f5aeaecc-e2de-40e8-b6b0-665f9a1d5100" />
