### PR TITLE
[refactor] jwt 토큰 인증, 보안 설정 수정

### DIFF
--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/SecurityConfig.java
@@ -51,7 +51,9 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/article/**").permitAll()
+                                .anyRequest().authenticated())
                 .addFilter(corsConfig.corsFilter())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)

--- a/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/farmsystem/sotserver/global/config/auth/jwt/JwtAuthenticationFilter.java
@@ -28,7 +28,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        final String accessToken = getAccessTokenFromHttpServletRequest(request);
+        String accessToken = request.getHeader(AUTHORIZATION);
+
+        // Authorization 헤더가 없거나 Bearer 토큰이 아니면 인증 절차 없이 다음 필터로 이동
+        if (!StringUtils.hasText(accessToken) || !accessToken.startsWith(BEARER)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Bearer 접두사 제거
+        accessToken = accessToken.substring(BEARER.length());
+
+
         jwtProvider.validateAccessToken(accessToken);
         final Long userId = jwtProvider.getSubject(accessToken);
         setAuthentication(request, userId);


### PR DESCRIPTION
…토큰 검사 수정

## 🌱 관련 이슈
- close : #27 
 
## 🌱 작업 사항
JwtAuthenticationFilter에서 토큰이 없어도 인증하는 과정에서 401 에러가 발생함
토큰이 없는 경우에 다음으로 넘어가도록 수정
목록 조회할때 토큰 없어도 조회가능

SecurityFilterChain 에서 api/article은 인증이 없어도 넘어가도록 수정함

